### PR TITLE
Added a patch to Galios to protect from MINSTKSZ calling sysconf

### DIFF
--- a/build
+++ b/build
@@ -46,7 +46,7 @@ fi
 #
 # Shell re-direct idiom used
 #
-# ((((command; echo $? >&3) | pipeline >&4) 3>&1) | (read res; exit $res)) 4>&1 
+# ((((command; echo $? >&3) | pipeline >&4) 3>&1) | (read res; exit $res)) 4>&1
 #
 #  1. Run command and capture its exit status on file descriptor (fd) 3
 #  2. Redirect stdout to fd 4
@@ -58,7 +58,7 @@ fi
 cmake_build() {
   dir=$1
   shift
-  echo 
+  echo
   echo "#### Building and installing package: $dir ####"
   date
   echo
@@ -87,7 +87,7 @@ act_tool_build() {
      thresh=$2
   fi
   dir=$1
-  echo 
+  echo
   echo "#### Building and installing package: $1 ####"
   date
   echo
@@ -105,11 +105,12 @@ act_tool_build() {
 echo "Applying patch to Galois library..."
 if [ ! -f patched ]
 then
-   (cd Galois; 
+   (cd Galois;
      patch -p0 < ../extra/Galois;
      patch -p0 < ../extra/Galois2;
      patch -p0 < ../extra/Galois3;
-     patch -p0 < ../extra/Galois4
+     patch -p0 < ../extra/Galois4;
+     patch -p0 < ../extra/Galois5
    )
    touch patched
 fi
@@ -124,7 +125,7 @@ fi
 
 echo "Log files and errors can be found in the logs/ directory."
 echo "Each number displayed corresponds to 10 lines in the output log file."
-echo 
+echo
 echo "Starting: `date`"
 
 #
@@ -161,7 +162,7 @@ echo
 act_tool_build annotate
 
 #
-# Build and install... 
+# Build and install...
 #
 
 # galois timer library

--- a/extra/Galois5
+++ b/extra/Galois5
@@ -1,0 +1,17 @@
+--- lonestar/scientific/cpu/longestedge/test/catch.hpp 2025-02-05 17:47:01.00000000 -0700
++++ lonestar/scientific/cpu/longestedge/test/catch.hpp 2025-02-05 17:48:01.00000000 -0700
+@@ -10732,7 +10732,14 @@ namespace Catch {
+ 
+     // 32kb for the alternate stack seems to be sufficient. However, this value
+     // is experimentally determined, so that's not guaranteed.
++#ifdef MINSIGSTKSZ && ( ( MINSIGSTKSZ + 2 ) > 2 )
++    // This is only true if MINSIGSTKSZ resolves to a number at preprocessor
++    //  expansion time, instead of sysconf ( SIGSTKSZ ) because it is going to
++    // be used as a constant
+     static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
++#else
++    static constexpr std::size_t sigStackSize = 32768; // >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
++#endif
+    
+     static SignalDefs signalDefs[] = {
+         { SIGINT,  "SIGINT - Terminal interrupt signal" },


### PR DESCRIPTION
In the Galios submodule, the file
`lonestar/scientific/cpu/longestedge/test/catch.hpp`
around line `10732`, a `static constexp` is declared that depends on the MINSIGSTKSZ
 
```
     // 32kb for the alternate stack seems to be sufficient. However, this value
     // is experimentally determined, so that's not guaranteed.
     static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
    
     static SignalDefs signalDefs[] = {
         { SIGINT,  "SIGINT - Terminal interrupt signal" },
```

This all works unless a _clever_ set of system headers in `signal.h` expands `MINSIGSTKSZ` to `sysconf ( SIGSTKSZ )`.

When that happens, a very obscure bug throws an error when the Galios package runs a check.
This pull request adds a patch to check if MINSIGSTKSZ is defined and is a number, not a call.  It that is not the case, then the constant is set to 32K.

There are some gratuitous spaces at the ends of line in ./build, but the key addition is the additional patch `extra/Galois5`